### PR TITLE
add postgresql-contrib-9.3 package

### DIFF
--- a/tasks/repmgr.yml
+++ b/tasks/repmgr.yml
@@ -4,3 +4,4 @@
   with_items:
     - repmgr
     - postgresql-9.3-repmgr
+    - postgresql-contrib-9.3


### PR DESCRIPTION
this dependency gives us `pg_archivecleanup`, which allows us to truncate WAL files on replica servers.
